### PR TITLE
_comedilib_h: Add 'const' to functions returning const char*

### DIFF
--- a/pycomedi/_comedilib_h.pxd
+++ b/pycomedi/_comedilib_h.pxd
@@ -35,7 +35,7 @@ cdef extern from 'comedilib.h':
 
     int comedi_loglevel(int loglevel)
     void comedi_perror(char *s)
-    char *comedi_strerror(int errnum)
+    const char *comedi_strerror(int errnum)
     int comedi_errno()
     int comedi_fileno(comedi_t *it)
 
@@ -44,8 +44,8 @@ cdef extern from 'comedilib.h':
     int comedi_get_n_subdevices(comedi_t *it)
     # COMEDI_VERSION_CODE handled by device.Device.get_version_code()
     int comedi_get_version_code(comedi_t *it)
-    char *comedi_get_driver_name(comedi_t *it)
-    char *comedi_get_board_name(comedi_t *it)
+    const char *comedi_get_driver_name(comedi_t *it)
+    const char *comedi_get_board_name(comedi_t *it)
     int comedi_get_read_subdevice(comedi_t *dev)
     int comedi_get_write_subdevice(comedi_t *dev)
 


### PR DESCRIPTION
This fixes compiler warnings about discarded const qualifiers:

pycomedi/_error.c:1353:22: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   __pyx_v_comedi_msg = comedi_strerror(__pyx_v_errno);
pycomedi/device.c:2605:15: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   __pyx_v_ret = comedi_get_driver_name(__pyx_v_self->__pyx_base.device);
pycomedi/device.c:2741:15: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   __pyx_v_ret = comedi_get_board_name(__pyx_v_self->__pyx_base.device);

Const is supported since Cython 0.18 (2013-01-28)
[1]:

  C const declarations are supported in the language.

[1]: https://github.com/cython/cython/blob/master/CHANGES.rst#018-2013-01-28